### PR TITLE
更新项目名时没有做名称唯一性校验

### DIFF
--- a/escheduler-api/src/main/java/cn/escheduler/api/service/ProjectService.java
+++ b/escheduler-api/src/main/java/cn/escheduler/api/service/ProjectService.java
@@ -242,7 +242,11 @@ public class ProjectService extends BaseService{
         if (checkResult != null) {
             return checkResult;
         }
-
+        Project tempProject = projectMapper.queryByName(projectName);
+        if (tempProject != null && tempProject.getId() != projectId) {
+            putMsg(result, Status.PROJECT_ALREADY_EXISTS, projectName);
+            return result;
+        }
         project.setName(projectName);
         project.setDesc(desc);
         project.setUpdateTime(new Date());


### PR DESCRIPTION
1更新项目名时没有做名称唯一性校验
2 建议将项目表名称设置为唯一索引