### PR TITLE
close #106 support to store resources in s3a(support aws s3 & minio)

### DIFF
--- a/escheduler-common/pom.xml
+++ b/escheduler-common/pom.xml
@@ -231,6 +231,29 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-aws</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-common</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-databind</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-annotations</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 		</dependency>

--- a/escheduler-common/src/main/java/cn/escheduler/common/utils/HadoopUtils.java
+++ b/escheduler-common/src/main/java/cn/escheduler/common/utils/HadoopUtils.java
@@ -34,12 +34,14 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static cn.escheduler.common.Constants.*;
 import static cn.escheduler.common.utils.PropertyUtils.getInt;
 import static cn.escheduler.common.utils.PropertyUtils.getString;
+import static cn.escheduler.common.utils.PropertyUtils.getPrefixedProperties;
 
 /**
  * hadoop utils
@@ -76,7 +78,9 @@ public class HadoopUtils implements Closeable {
                         if(defaultFS.startsWith("file")){
                             String defaultFSProp = getString(FS_DEFAULTFS);
                             if(StringUtils.isNotBlank(defaultFSProp)){
+                                Map<String, String> fsRelatedProps = getPrefixedProperties("fs.");
                                 configuration.set(FS_DEFAULTFS,defaultFSProp);
+                                fsRelatedProps.entrySet().stream().forEach(entry -> configuration.set(entry.getKey(), entry.getValue()));
                             }else{
                                 logger.error("property:{} can not to be empty, please set!");
                                 throw new RuntimeException("property:{} can not to be empty, please set!");
@@ -316,7 +320,13 @@ public class HadoopUtils implements Closeable {
      * @return data hdfs path
      */
     public static String getHdfsDataBasePath() {
-        return getString(DATA_STORE_2_HDFS_BASEPATH);
+        String basePath = getString(DATA_STORE_2_HDFS_BASEPATH);
+        if ("/".equals(basePath)) {
+            // if basepath is configured to /,  the generated url may be  //default/resources (with extra leading /)
+            return "";
+        } else {
+            return basePath;
+        }
     }
 
     /**
@@ -365,7 +375,7 @@ public class HadoopUtils implements Closeable {
      * @return file directory of tenants on hdfs
      */
     private static String getHdfsTenantDir(String tenantCode) {
-        return String.format("%s/%s", getString(DATA_STORE_2_HDFS_BASEPATH), tenantCode);
+        return String.format("%s/%s", getHdfsDataBasePath(), tenantCode);
     }
 
 

--- a/escheduler-common/src/main/java/cn/escheduler/common/utils/PropertyUtils.java
+++ b/escheduler-common/src/main/java/cn/escheduler/common/utils/PropertyUtils.java
@@ -22,6 +22,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import static cn.escheduler.common.Constants.COMMON_PROPERTIES_PATH;
@@ -188,5 +190,20 @@ public class PropertyUtils {
                                          T defaultValue) {
         String val = getString(key);
         return val == null ? defaultValue : Enum.valueOf(type, val);
+    }
+
+    /**
+     * get all properties with specified prefix, like: fs.
+     * @param prefix prefix to search
+     * @return
+     */
+    public static Map<String, String> getPrefixedProperties(String prefix) {
+        Map<String, String> matchedProperties = new HashMap<>();
+        for (String propName : properties.stringPropertyNames()) {
+            if (propName.startsWith(prefix)) {
+                matchedProperties.put(propName, properties.getProperty(propName));
+            }
+        }
+        return matchedProperties;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,11 @@
 				<artifactId>hadoop-yarn-common</artifactId>
 				<version>${hadoop.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>org.apache.hadoop</groupId>
+				<artifactId>hadoop-aws</artifactId>
+				<version>${hadoop.version}</version>
+			</dependency>
 
 			<dependency>
 				<groupId>javax.servlet</groupId>


### PR DESCRIPTION
现在, ES支持3种不同的存储来存储Resource:
1. HDFS:  本来也支持


2. FILE: 本地文件, 之前代码也支持, 只是需要文档写的更清楚些, 需要修改如下位置:
2.1 修改: common/hadoop/hadoop.properties 的 fs.defaultFS
   ```
     fs.defaultFS=file:///home/escheduler_resource
   ```
2.2 注意同时修改:  common/common.properties 中的 data.store2hdfs.basepath
  ```
   data.store2hdfs.basepath=/home/escheduler_resource
  ```
2.3 如果EasyScheduler之前已经创建过租户, 需要额外先创建   /home/escheduler_resource/租户名/resources   文件夹

3. AWS S3,  以及Minio Sever (https://github.com/minio/minio),  通过Minio Server又可以支持: Azure, GCS, NAS等. 以 minio server举例, (AWS S3应该可以直接用, 配置也差不多), 比如: 提前创建了 bucket:  escheduler
3.1 修改: common/hadoop/hadoop.properties 的 
   ```
    fs.defaultFS=s3a://escheduler
    fs.s3a.endpoint=http://192.168.199.91:9010
    fs.s3a.access.key=A3DXS30FO22544RE
    fs.s3a.secret.key=OloCLq3n+8+sdPHUhJ21XrSxTC+JK
   ```
3.2 注意同时修改:  common/common.properties 中的 data.store2hdfs.basepath
  ```
   data.store2hdfs.basepath=/
  ```

3.3 如果EasyScheduler之前已经创建过租户, 需要额外在minio先创建  /es_tenant_id/resources  目录, 但是由于 minio / S3 中的目录是虚拟的, 可以先创建 一个 es_tenant_id/resources/.keep 空文件, 使得S3/Minio认为这个目录是存在的.  具体方法, 比如在Minio web browser中直接先输入 url:   http://192.168.199.91:9010/minio/escheduler/your_tanent_id/resources/     再上传一个空的 .keep 文件(文件名随意, 但是尽量一直保留, 避免后续所有用户上传文件删除后, 该虚拟目录又不存在了!)

